### PR TITLE
fix script by removing whitespace

### DIFF
--- a/SEcontexts_parser.py
+++ b/SEcontexts_parser.py
@@ -3,7 +3,6 @@
 
 import re
 import os
-import requests
 
 value = None
 def help():
@@ -22,10 +21,10 @@ def sepologparser_inet():
             pat = r"""avc:\s*denied\s*({\s*[^}]*\s*})\s+.*?scontext=u:r:([^:]*):s\d+.*?tcontext=.*?:(\w{2,}):s0.*?\s+tclass=([^\s:]*)\s+"""
             for what, scnt, tcnt, tc in re.findall(pat, data):
                 output_file.write("allow {} {}:{} {} ".format(scnt, tcnt, tc, what))
-		output_file.write(";\n")
+                output_file.write(";\n")
         os.system('sort allows.te | uniq > temp.te')
-	os.system('rm allows.te && mv temp.te allows.te')
-        os.system('cls' if os.name == 'nt' else 'clear') 
+        os.system('rm allows.te && mv temp.te allows.te')
+        os.system('cls' if os.name == 'nt' else 'clear')
 
 def sepologparser_local():
         with open('log.txt') as input_file, open('allows.te', 'w') as output_file:
@@ -33,9 +32,9 @@ def sepologparser_local():
             pat = r"""avc:\s*denied\s*({\s*[^}]*\s*})\s+.*?scontext=u:r:([^:]*):s\d+.*?tcontext=.*?:(\w{2,}):s0.*?\s+tclass=([^\s:]*)\s+"""
             for what, scnt, tcnt, tc in re.findall(pat, text):
                 output_file.write("allow {} {}:{} {} ".format(scnt, tcnt, tc, what))
-		output_file.write(";\n")
+                output_file.write(";\n")
         os.system('sort allows.te | uniq > temp.te')
-	os.system('rm allows.te && mv temp.te allows.te')
+        os.system('rm allows.te && mv temp.te allows.te')
         os.system('cls' if os.name == 'nt' else 'clear') 
 
 def parse_fcf():


### PR DESCRIPTION
I couldn't make it run on windows but I was able to run it inside wsl by fixing whitespace and removing requests library. There is no longer a  python-requests library in ubuntu. So it had to go. You might wanna take a look at windows script, it just opens empty terminal, probably because of .bat.

Removing white space fixed this:
```
~/SEcontexts_parser$ python3 SEcontexts_parser.py
  File "/home/username/SEcontexts_parser/SEcontexts_parser.py", line 25
    output_file.write(";\n")
TabError: inconsistent use of tabs and spaces in indentation
```

Removing requests library fixed this:
```
~/SEcontexts_parser$ python3 SEcontexts_parser.py
Traceback (most recent call last):
  File "/home/username/SEcontexts_parser/SEcontexts_parser.py", line 6, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```
